### PR TITLE
Getting dbname from env if v$database in unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.9
+ * Pulling the database name from the env if v$database is unavailable.
+
 ## 1.1.8
  * Swapping singer-python for pipelinewise-singer-python
  * This variant uses orjson for serializing 40-50x faster than other libraries.

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -252,8 +252,12 @@ def produce_pk_constraints(conn, filter_schemas):
 def get_database_name(connection):
    cur = connection.cursor()
 
-   rows = cur.execute("SELECT name FROM v$database").fetchall()
-   return rows[0][0]
+   try:
+      rows = cur.execute("SELECT name FROM v$database").fetchall()
+      return rows[0][0]
+   except cx_Oracle.DatabaseError as ex:
+      rows = cur.execute("SELECT UPPER(sys_context('USERENV','DB_NAME')) AS DB_NAME FROM dual").fetchall()
+      return rows[0][0]
 
 def produce_column_metadata(connection, database_name, table_info, table_schema, table_name, pk_constraints, column_schemas, cols):
    mdata = {}


### PR DESCRIPTION
## Problem

There may be a situation where v$database is unavailable due to permissions, this causes the tap to not work.

## Proposed changes

If v$database is unavailable, pull the database name from the environment.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions