### PR TITLE
Change order by to column_id

### DIFF
--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -316,7 +316,7 @@ def discover_columns(connection, table_info, filter_schemas, filter_tables, use_
              DATA_PRECISION, DATA_SCALE
         FROM all_tab_columns
        WHERE {filter} AND owner IN ({{}})
-       ORDER BY owner, table_name, column_name
+       ORDER BY owner, table_name, column_id
       """.format(",".join(binds_sql))
    else:
       sql = f"""
@@ -327,7 +327,7 @@ def discover_columns(connection, table_info, filter_schemas, filter_tables, use_
              DATA_PRECISION, DATA_SCALE
         FROM all_tab_columns
        WHERE {filter}
-       ORDER BY owner, table_name, column_name
+       ORDER BY owner, table_name, column_id
       """
 
    LOGGER.info("fetching column info")

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -501,7 +501,7 @@ def sync_method_for_streams(streams, state, default_replication_method):
 
       md_map = metadata.to_map(stream.metadata)
       desired_columns = [c for c in stream.schema.properties.keys() if common.should_sync_column(md_map, c)]
-      desired_columns.sort()
+      #desired_columns.sort()
 
       if len(desired_columns) == 0:
          LOGGER.warning('There are no columns selected for stream %s, skipping it', stream.tap_stream_id)

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -547,7 +547,7 @@ def sync_traditional_stream(conn_config, stream, state, sync_method, end_scn):
    LOGGER.info("Beginning sync of stream(%s) with sync method(%s)", stream.tap_stream_id, sync_method)
    md_map = metadata.to_map(stream.metadata)
    desired_columns = [c for c in stream.schema.properties.keys() if common.should_sync_column(md_map, c)]
-   desired_columns.sort()
+   #desired_columns.sort()
    if len(desired_columns) == 0:
       LOGGER.warning('There are no columns selected for stream %s, skipping it', stream.tap_stream_id)
       return state


### PR DESCRIPTION
Will ensure that tables are synced with columns in the correct order

## Problem

Columns are being extracted from the source in alphabetical order. 

## Proposed changes

While this may be a 'cosmetic' issue, there are some scenarios where the ordering of columns is important and is determined by the `column_id` in `all_tab_columns`

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions