### PR TITLE
Offset value for Oracle

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,32 @@
-# Description of change
-(write a short description or paste a link to JIRA)
+## Problem
 
-# Manual QA steps
- - 
- 
-# Risks
- - 
- 
-# Rollback steps
- - revert this branch
+_Describe the problem your PR is trying to solve_
+
+## Proposed changes
+
+_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
+If it fixes a bug or resolves a feature request, be sure to link to that issue._
+
+
+## Types of changes
+
+What types of changes does your code introduce to PipelineWise?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+
+## Checklist
+
+- [ ] Description above provides context of the change
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Unit tests for changes (not needed for documentation changes)
+- [ ] CI checks pass with my changes
+- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
+- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
+- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
+- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
+- [ ] Relevant documentation is updated including usage instructions

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ Using offset_value < 0 would result in an overlapping set of records being read 
 
 Using offset_value > 0 may result in data being missed. However it can be useful if a period (month-year) is being used. This prevents the tap from using period >= last-read-period and doubling up on the extract.
 
-Usage (offsetting by -ve 3 hours):
+Usage (offsetting by +1 days):
 ```json
 {
-  "offset_value": -10800
+  "offset_value": 1
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ information to correctly replicate decimal data without loss. For the Floats and
 }
 ```
 
+Optional:
+
+To avoid problems with uncommitted changes being read, you can set `offset_value` to add to the value found in the STATE for INCREMENTAL loads. If the value provided is for a datetime replication key then the `offset_value` is read as seconds to offset by, otherwise the value is used as provided.
+
+Using offset_value < 0 would result in an overlapping set of records being read each time the tap is run.
+
+Using offset_value > 0 may result in data being missed. However it can be useful if a period (month-year) is being used. This prevents the tap from using period >= last-read-period and doubling up on the extract.
+
+Usage (offsetting by -ve 3 hours):
+```json
+{
+  "offset_value": -10800
+}
+```
+
 ### To run tests:
 
 Tests require Oracle on Amazon RDS >= 12.1, and a user called `ROOT`.

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ Using offset_value < 0 would result in an overlapping set of records being read 
 
 Using offset_value > 0 may result in data being missed. However it can be useful if a period (month-year) is being used. This prevents the tap from using period >= last-read-period and doubling up on the extract.
 
-Usage (offsetting by +1 days):
+Usage (offsetting by +1 day in seconds = 24*3600):
 ```json
 {
-  "offset_value": 1
+  "offset_value": 86400
 }
 ```
 

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -654,6 +654,8 @@ def main_impl():
       full_table.BATCH_SIZE = int(args.config.get('full_table_sync_batch_size'))
    full_table.USE_ORA_ROWSCN = bool(args.config.get('use_ora_rowscn', True))
    use_singer_decimal = bool(args.config.get('use_singer_decimal', False))
+   incremental.OFFSET_VALUE = args.config.get('offset_value',0)
+
 
    if args.discover:
       filter_schemas_prop = args.config.get('filter_schemas')

--- a/tap_oracle/sync_strategies/incremental.py
+++ b/tap_oracle/sync_strategies/incremental.py
@@ -61,7 +61,7 @@ def sync_table(conn_config, stream, state, desired_columns):
 
    with metrics.record_counter(None) as counter:
       if replication_key_value:
-         LOGGER.info(f"Resuming Incremental replication from {replication_key} = {replication_key_value} + {OFFSET_VALUE}", replication_key, replication_key_value)
+         LOGGER.info(f"Resuming Incremental replication from {replication_key} = {replication_key_value} + {OFFSET_VALUE}")
          casted_where_clause_arg = common.prepare_where_clause_arg(replication_key_value, replication_key_sql_datatype)
 
          select_sql      = """SELECT {}

--- a/tap_oracle/sync_strategies/incremental.py
+++ b/tap_oracle/sync_strategies/incremental.py
@@ -59,27 +59,24 @@ def sync_table(conn_config, stream, state, desired_columns):
    replication_key_value = singer.get_bookmark(state, stream.tap_stream_id, 'replication_key_value')
    replication_key_sql_datatype = md.get(('properties', replication_key)).get('sql-datatype')
 
+   if replication_key_sql_datatype == 'DATE' or replication_key_sql_datatype.startswith('TIMESTAMP'):
+      OFFSET_VALUE = f"INTERVAL '{OFFSET_VALUE}' SECOND"
+
    with metrics.record_counter(None) as counter:
       if replication_key_value:
          LOGGER.info(f"Resuming Incremental replication from {replication_key} = {replication_key_value} + {OFFSET_VALUE}")
          casted_where_clause_arg = common.prepare_where_clause_arg(replication_key_value, replication_key_sql_datatype)
 
-         select_sql      = """SELECT {}
-                                FROM {}.{}
-                               WHERE {} >= {} + {}
-                               ORDER BY {} ASC
-                                """.format(','.join(escaped_columns),
-                                           escaped_schema, escaped_table,
-                                           replication_key, casted_where_clause_arg,
-                                           OFFSET_VALUE,replication_key
-                                           )
+         select_sql      = f"""SELECT {','.join(escaped_columns)}
+                                FROM {escaped_schema}.{escaped_table}
+                               WHERE {replication_key} >= {casted_where_clause_arg} + {OFFSET_VALUE}
+                               ORDER BY {replication_key} ASC
+                                """
       else:
-         select_sql      = """SELECT {}
-                                FROM {}.{}
-                               ORDER BY {} ASC
-                               """.format(','.join(escaped_columns),
-                                          escaped_schema, escaped_table,
-                                          replication_key)
+         select_sql      = f"""SELECT {','.join(escaped_columns)}
+                                FROM {escaped_schema}.{escaped_table}
+                               ORDER BY {replication_key} ASC
+                               """
 
       rows_saved = 0
       LOGGER.info("select %s", select_sql)


### PR DESCRIPTION
## Problem

The default behaviour of incremental loads is to use greater than or equal to as the comparison operator. This has the potential to reload large amounts of data when the replication-key we use is discrete (e.g. month)

## Proposed changes

Add an offset_value configuration option which allows the tap to offset the state bookmark replication-key-value by a given amount. The amount can be positive or negative:

positive - skip forward and potentially omit data in the 'gap' between the replication-key-value and the offset amount
negative - skip backwards and reload data - this is useful if the data source you are referencing has uncommitted transactions


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions