### PR TITLE
fix: make sure key_properties is not null for views

### DIFF
--- a/tap_oracle/sync_strategies/common.py
+++ b/tap_oracle/sync_strategies/common.py
@@ -18,6 +18,8 @@ def send_schema_message(stream, bookmark_properties):
     s_md = metadata.to_map(stream.metadata)
     if s_md.get((), {}).get('is-view'):
         key_properties = s_md.get((), {}).get('view-key-properties')
+        if not key_properties:
+            key_properties = []
     else:
         key_properties = s_md.get((), {}).get('table-key-properties')
 


### PR DESCRIPTION
PR text written by @berenddeboer

For views key_properties was null, and my postgres target crashed when that happened.

## Problem

For views key_properties was null, and my postgres target crashed when that happened.

## Proposed changes

Explicitly assign the empty array, that's the value I have for my tables.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions