### PR TITLE
feat: Add tags to record_count messages to identify table

### DIFF
--- a/tap_oracle/sync_strategies/full_table.py
+++ b/tap_oracle/sync_strategies/full_table.py
@@ -58,6 +58,10 @@ def sync_view(conn_config, stream, state, desired_columns):
       singer.write_message(activate_version_message)
 
    with metrics.record_counter(None) as counter:
+     
+      counter.tags["schema"] = escaped_schema
+      counter.tags["table"] = escaped_table
+
       select_sql      = 'SELECT {} FROM {}.{}'.format(','.join(escaped_columns),
                                                       escaped_schema,
                                                       escaped_table)
@@ -121,6 +125,10 @@ def sync_table(conn_config, stream, state, desired_columns):
       singer.write_message(activate_version_message)
 
    with metrics.record_counter(None) as counter:
+     
+      counter.tags["schema"] = escaped_schema
+      counter.tags["table"] = escaped_table
+     
       ora_rowscn = singer.get_bookmark(state, stream.tap_stream_id, 'ORA_ROWSCN')
       if not USE_ORA_ROWSCN:
          # Warning there is not restart recovery if the ORA_ROWSCN is ignored.

--- a/tap_oracle/sync_strategies/incremental.py
+++ b/tap_oracle/sync_strategies/incremental.py
@@ -68,6 +68,10 @@ def sync_table(conn_config, stream, state, desired_columns):
       typed_offset_value = f"INTERVAL '{OFFSET_VALUE}' SECOND"
 
    with metrics.record_counter(None) as counter:
+      
+      counter.tags["schema"] = escaped_schema
+      counter.tags["table"] = escaped_table
+      
       if replication_key_value:
          LOGGER.info(f"Resuming Incremental replication from {replication_key} = {replication_key_value} + {typed_offset_value}")
          casted_where_clause_arg = common.prepare_where_clause_arg(replication_key_value, replication_key_sql_datatype)

--- a/tap_oracle/sync_strategies/log_miner.py
+++ b/tap_oracle/sync_strategies/log_miner.py
@@ -208,7 +208,11 @@ def sync_tables_logminer(cur, streams, state, start_scn, end_scn):
       rows_saved = 0
       columns_for_record = desired_columns + ['scn', '_sdc_deleted_at']
       with metrics.record_counter(None) as counter:
-         LOGGER.info("Examing log for table %s", stream.tap_stream_id)
+         
+         counter.tags["schema"] = schema_name
+         counter.tags["table"] = stream.table
+         
+         LOGGER.info("Examining log for table %s", stream.tap_stream_id)
          common.send_schema_message(stream, ['lsn'])
          LOGGER.info("mine_sql=%s", mine_sql)
          for op, redo, scn, cscn, commit_ts, *col_vals in cur.execute(mine_sql, binds):


### PR DESCRIPTION
## Problem

On the majority of the other taps we use, the `record_count` metric messages show the table or stream that is being synced. This helps when aggregating logs in AWS using Logs Insights and is generally helpful for developers.

## Proposed changes

The update changes the counter messages to contain tags:

```
time=2023-06-06 16:51:32 name=singer level=INFO message=METRIC: b'{"type":"counter","metric":"record_count","value":63721,"tags":{"schema":"OLDSTUFF","table":"STONEHENGE"}}'
```
## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions