### PR TITLE
Feature/remove number to boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.4
+ * Breaking Change! Removing logic to assuming an Oracle number(1) datatype is a boolean.
+
 ## 1.2.3
  * Add tags to the record_count (database / schema)
  * Adding logo for pipelinewise-tap-oracle

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-oracle',
-      version='1.2.3',
+      version='1.2.4',
       description='Singer.io tap for extracting data from Oracle - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -89,12 +89,7 @@ def schema_for_column(c, pks_for_table, use_singer_decimal):
    numeric_scale = c.numeric_scale if c.numeric_scale is not None else DEFAULT_NUMERIC_SCALE
    # Precision is always non-zero and defaults to 38 digits
    numeric_precision = c.numeric_precision or DEFAULT_NUMERIC_PRECISION
-   #Bool
-   if data_type == 'number' and numeric_scale == 0 and numeric_precision == 1:
-      result.type = nullable_column(c.column_name, 'boolean', pks_for_table)
-      return result
-
-   elif data_type == 'number' and numeric_scale <= 0:
+   if data_type == 'number' and numeric_scale <= 0:
       result.type = nullable_column(c.column_name, 'integer', pks_for_table)
 
       return result


### PR DESCRIPTION
## Problem

The current version of this tap incorporated these change from this variant of pipelinewise-tap-oracle https://gitlab.com/autoidm/tap-oracle/-/commit/9f3672f4e3293d50443daedbd020eac06e7592ce .

One of the features makes the assumption if you have number data with a precision 1 and a scale of 0 that you are dealing with boolean data.  While this assumption is often correct it is possible in Oracle to define a data type of number(1) and store single integer values i.e. 0 to 9 safely.

This tap will incorrectly modify the data in example provided to a Boolean. 

## Proposed changes

Deprecate the changes to convert a number(1) datatype in Oracle to a boolean. 

Please Note: This is a breaking change. If you are expecting a boolean as a resultant datatype. Please do some post load transformation to convert the number(1) to a boolean on the target.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions