### PR TITLE
Corrects bug in testing list for SYS in filter_sys_or_not function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.5
+ * Resolving bug in the filter_sys_or_not function to handle an empty schema filter.
+   The fix also allows the SYS schema to be anywhere in the list.
+
 ## 1.2.4
  * Breaking Change! Removing logic to assuming an Oracle number(1) datatype is a boolean.
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-oracle',
-      version='1.2.4',
+      version='1.2.5',
       description='Singer.io tap for extracting data from Oracle - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_oracle/__init__.py
+++ b/tap_oracle/__init__.py
@@ -181,7 +181,7 @@ def schema_for_column(c, pks_for_table, use_singer_decimal):
 
 def filter_sys_or_not(filter_schemas):
     filter = "owner != 'SYS'"
-    if (filter_schemas[0] == 'SYS'): filter = "1=1"
+    if ('SYS' in filter_schemas): filter = "1=1"
     return filter
 
     


### PR DESCRIPTION
## Problem

The logic to test for SYS in the filter_schema list assumes 1. There is a populated list, and 2. SYS is always the first item in the list. The result is an IndexError.

![image](https://github.com/s7clarke10/pipelinewise-tap-oracle/assets/84364906/4b16b18e-aaef-4f47-9d61-014fc4d53120)

## Proposed changes

Change the logic to test whether SYS exists in the list using an `in` test.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions

Tests:

This small program tests the results.

```
def filter_sys_or_not(filter_schemas):
    filter = "owner != 'SYS'"
    if ('SYS' in filter_schemas): filter = "1=1"
    return filter

# Expecting where clause to be '1=1' as SYS exists in the list

>>> filter=["SCOTT","SYS","DSS"]
>>> x = filter_sys_or_not(filter)
>>> print(f"{x=}")
x='1=1'

# Expecting where SYS to be excluded as SYS is not in the list

>>> filter=["SCOTT","BOB","DSS"]
>>> x = filter_sys_or_not(filter)
>>> print(f"{x=}")
x="owner != 'SYS'"
```
    